### PR TITLE
Make Backend configuration more flexible

### DIFF
--- a/backend/duo-backend/templates/deployment.yaml
+++ b/backend/duo-backend/templates/deployment.yaml
@@ -53,6 +53,9 @@ spec:
               port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: uploads
+              mountPath: /home/node/app/uploads/
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -65,3 +68,11 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+      volumes:
+        - name: uploads
+          {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "duo-backend.fullname" . }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}

--- a/backend/duo-backend/templates/pvc.yaml
+++ b/backend/duo-backend/templates/pvc.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: "{{ include "duo-backend.fullname" . }}"
+  labels:
+    {{- include "duo-backend.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - {{ required ".Values.persistence.accessMode must be set" .Values.persistence.accessMode }}
+  resources:
+    requests:
+      storage: {{ required ".Values.persistence.size must be set" .Values.persistence.size }}
+  {{- with .Values.persistence.storageClassName }}
+  storageClassName: {{ . }}
+  {{- end }}
+{{- end }}

--- a/backend/duo-backend/values.yaml
+++ b/backend/duo-backend/values.yaml
@@ -9,12 +9,12 @@ image:
   tag: develop
   pullPolicy: Always
 
-env:
-  - name: DATABASE_URL
-    valueFrom:
-      secretKeyRef:
-        name: duo-db-svcbind-custom-user
-        key: uri
+env: []
+#   - name: DATABASE_URL
+#     valueFrom:
+#       secretKeyRef:
+#         name: duo-db-svcbind-custom-user
+#         key: uri
 
 envFrom: {}
 

--- a/backend/duo-backend/values.yaml
+++ b/backend/duo-backend/values.yaml
@@ -57,6 +57,15 @@ ingress:
 
 resources: {}
 
+# -- Backend component needs a storage for Uploads.
+persistence:
+  # -- If false, an EmptyDir is used.
+  enabled: false
+  size: ""
+  storageClassName: ""
+  # Should be ReadWriteMany, unless only one Pod is deployed.
+  accessMode: ReadWriteMany
+
 nodeSelector: {}
 
 tolerations: []

--- a/user-office-app/.gitignore
+++ b/user-office-app/.gitignore
@@ -1,0 +1,2 @@
+charts/
+Chart.lock

--- a/user-office-app/Chart.yaml
+++ b/user-office-app/Chart.yaml
@@ -41,6 +41,7 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     version: 15.5.11
     alias: duo-db
+    condition: duo-db.enabled
   - name: duo-scheduler-backend
     condition: scheduler.enabled
     version: 0.1.0

--- a/user-office-app/values.yaml
+++ b/user-office-app/values.yaml
@@ -27,6 +27,9 @@ duo-factory:
   fullnameOverride: duo-factory
 
 duo-db:
+  # If disabled, database configuration for external Postgresql should be
+  # provided via .duo-backend.env environment.
+  enabled: true
   fullnameOverride: duo-db
   serviceBindings:
     enabled: true


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description

This PR introduces support for optional Persistent Volume Claim or Backend helm chart which solves 2 potential issues:
- Some Kubernetes runtimes do not allow containers run as root which prevents the backend NodeJS application from starting as it cannot write in `/home/node/app/uploads/` in a container
- Uploads can be configured to be persistent
- With the changes in Bitnami containers support policy (https://github.com/bitnami/containers/issues/75671) make Postgresql Helm chart dependency optional

## How Has This Been Tested

The changed Helm chart was deployed on OKD 4.17 (RedHat Openshift Upstream) with restricted SecurityContext.
The introduction of the Volume in `/home/node/app/uploads/` fixed the Backend startup problem.

## Docs Updated

- [x] All relevant doc has been updated (documented new options)
