### PR TITLE
chore: Update service port to 8080 in scheduler-frontend's values.yaml

### DIFF
--- a/scheduler-frontend/duo-scheduler-frontend/values.yaml
+++ b/scheduler-frontend/duo-scheduler-frontend/values.yaml
@@ -26,7 +26,7 @@ securityContext: {}
 
 service:
   type: ClusterIP
-  port: 80
+  port: 8080
 
 ingress:
   enabled: true


### PR DESCRIPTION
This change is necessary due to the use of an unprivileged NGINX container: https://github.com/UserOfficeProject/user-office-scheduler/pull/54