### PR TITLE
Remove SYS_ADMIN capability from factory

### DIFF
--- a/factory/duo-factory/values.yaml
+++ b/factory/duo-factory/values.yaml
@@ -54,10 +54,7 @@ podAnnotations: {}
 
 podSecurityContext: {}
 
-securityContext:
-  capabilities:
-    add:
-      - SYS_ADMIN
+securityContext: {}
 
 service:
   type: ClusterIP


### PR DESCRIPTION
## Description

Remove SYS_ADMIN capability from factory

## Motivation and Context

When deploying this to our k8s cluster our infrastructure team raised some concern over this and it was unclear to us if it was actually required.

## How Has This Been Tested

The chart has been successfully deployed with this change and basic testing performed (downloading a proposal pdf) however more extensive testing may be required.
